### PR TITLE
FRONTEND-104 fixes bug with weird fab behaviour in location list. 

### DIFF
--- a/app/src/main/res/layout/fragment_location_list.xml
+++ b/app/src/main/res/layout/fragment_location_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -24,4 +24,4 @@
         app:layout_anchor="@id/list"
         app:layout_anchorGravity="bottom|right|end" />
 
-</android.support.design.widget.CoordinatorLayout>
+</FrameLayout>


### PR DESCRIPTION
Changes coordinatorlayout to framelayout due to duplicate/nested coordinatorlayout from parent xml (activity_event.xml). 