### PR TITLE
#FRONTEND-120 Fixes gradle warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
-apply plugin: 'android-apt'
+//apply plugin: 'android-apt'
+//apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'jacoco-android'
 
 android {
@@ -41,7 +42,6 @@ repositories {
     jcenter()
 }
 
-apply plugin: 'com.neenbedankt.android-apt'
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
@@ -54,6 +54,9 @@ dependencies {
     compile 'com.android.support:support-v4:25.2.0'
     compile 'com.android.support:design:25.2.0'
     compile 'com.android.support:gridlayout-v7:25.2.0'
+    compile 'com.android.support:customtabs:25.2.0'
+    compile 'com.android.support:mediarouter-v7:25.2.0'
+
 
     // Mosby:
     compile "com.hannesdorfmann.mosby:mvp:${mosby_version}"
@@ -66,11 +69,11 @@ dependencies {
 
     // IcePick
     compile 'frankiesardo:icepick:3.2.0'
-    apt 'frankiesardo:icepick-processor:3.2.0'
+    provided 'frankiesardo:icepick-processor:3.2.0'
 
     // Parceler
-    compile 'org.parceler:parceler-api:1.1.6'
-    annotationProcessor 'org.parceler:parceler:1.1.6'
+    //compile 'org.parceler:parceler-api:1.1.6'
+    //annotationProcessor 'org.parceler:parceler:1.1.6'
 
     // Retrofit
     compile "com.squareup.retrofit2:retrofit:${retrofit_version}"
@@ -91,8 +94,8 @@ dependencies {
     compile "io.reactivex:rxjava:${rxjava_version}"
 
     // Dagger2
-    apt "com.google.dagger:dagger-compiler:${dagger_version}"
     compile "com.google.dagger:dagger:${dagger_version}"
+    annotationProcessor "com.google.dagger:dagger-compiler:${dagger_version}"
 
     //--- TESTING ---//
     // hack for the robolectric api > 22 problem
@@ -112,8 +115,6 @@ dependencies {
     testCompile 'com.android.support:support-compat:25.2.0'
     testCompile 'com.android.support:support-annotations:25.2.0'
 
-    testCompile 'com.android.support:support-compat:25.2.0'
-    testCompile 'com.android.support:support-annotations:25.2.0'
 
     // Picasso Image Downloader
     compile 'com.squareup.picasso:picasso:2.5.0'
@@ -125,7 +126,7 @@ dependencies {
     compile 'joda-time:joda-time:2.9.7'
     compile 'com.fatboyindustrial.gson-jodatime-serialisers:gson-jodatime-serialisers:1.5.0'
 
-    compile 'com.google.android.gms:play-services:10.0.1'
+    compile 'com.google.android.gms:play-services:10.2.0'
     compile 'com.google.maps.android:android-maps-utils:0.4'
 
     // Facebook

--- a/app/src/main/java/io/hobaskos/event/eventapp/data/AccountManager.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/data/AccountManager.java
@@ -3,7 +3,6 @@ package io.hobaskos.event.eventapp.data;
 import com.facebook.AccessToken;
 import com.facebook.login.LoginManager;
 
-import org.parceler.Repository;
 
 import io.hobaskos.event.eventapp.data.model.User;
 import io.hobaskos.event.eventapp.data.repository.UserRepository;

--- a/app/src/main/java/io/hobaskos/event/eventapp/data/model/GeoPoint.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/data/model/GeoPoint.java
@@ -2,13 +2,11 @@ package io.hobaskos.event.eventapp.data.model;
 
 import android.os.Parcelable;
 
-import org.parceler.Parcel;
 
 /**
  * Created by osvold.hans.petter on 08.02.2017.
  */
 
-@Parcel
 public class GeoPoint implements Parcelable {
 
     private double lat;

--- a/app/src/main/java/io/hobaskos/event/eventapp/data/model/Location.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/data/model/Location.java
@@ -6,12 +6,10 @@ import android.os.Parcelable;
 import android.util.EventLogTags;
 
 import org.joda.time.LocalDateTime;
-import org.parceler.Parcel;
 
 /**
  * Created by osvold.hans.petter on 08.02.2017.
  */
-@Parcel
 public class Location implements Parcelable {
 
     private long id;

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsFragment.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsFragment.java
@@ -42,7 +42,7 @@ public class FilterEventsFragment extends BaseFragment
         implements FilterEventsView, GoogleApiClient.OnConnectionFailedListener {
     public final static String TAG = FilterEventsFragment.class.getName();
 
-    @BindView(R.id.toolbar) Toolbar toolbar;
+    Toolbar toolbar;
     @BindView(R.id.seekBar) SeekBar seekBar;
     @BindView(R.id.seekBarText) TextView seekBarText;
     @BindView(R.id.categorySpinner) Spinner spinner;

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/event/list/EventsFragment.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/event/list/EventsFragment.java
@@ -47,8 +47,7 @@ public class EventsFragment extends
 
     // Views
     @BindView(R.id.recyclerView)RecyclerView recyclerView;
-    @BindView(R.id.progress) ProgressBar progressBar;
-    @BindView(R.id.toolbar) Toolbar toolbar;
+    Toolbar toolbar;
     @BindView(R.id.contentView) SwipeRefreshLayout swipeRefreshLayout;
 
     TextView emptyResultView;


### PR DESCRIPTION
Fixes gradle warnings:

Warning:Using incompatible plugins for the annotation processing: android-apt. This may result in an unexpected behavior.

All com.android.support libraries must use the exact same version specification (mixing versions can lead to runtime crashes). Found versions 25.2.0, 25.0.0, 24.0.0. Examples include com.android.support:animated-vector-drawable:25.2.0 and com.android.support:customtabs:25.0.0