### PR TITLE
#FRONTEND-188 Splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,15 +38,29 @@
 
 
         <!-- Activities -->
+        <!-- Splash screen -->
         <activity
-            android:name=".ui.main.MainActivity"
+            android:name=".ui.splash.SplashScreenActivity"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.main.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <!--
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            -->
         </activity>
 
         <activity

--- a/app/src/main/java/io/hobaskos/event/eventapp/data/storage/FilterSettings.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/data/storage/FilterSettings.java
@@ -23,12 +23,12 @@ public class FilterSettings {
     public static final String FILTER_EVENTS_CATEGORY_KEY = "filter_events_category_key";
     public static final String FILTER_EVENTS_CURRENT_LOCATION_KEY = "filter_events_current_location_key";
 
-    public static final int DEFAULT_DISTANCE = 10;
+    public static final int DEFAULT_DISTANCE = 20;
     public static final String DEFAULT_PLACE_NAME = "";
     public static final double DEFAULT_PLACE_LAT = 0;
     public static final double DEFAULT_PLACE_LON = 0;
     public static final long DEFAULT_CATEGORY_ID = 0;
-    public static final boolean DEFAULT_CURRENT_LOCATION = false;
+    public static final boolean DEFAULT_CURRENT_LOCATION = true;
 
     public int getDistance() {
         return persistentStorage.getInt(FILTER_EVENTS_DISTANCE_KEY, DEFAULT_DISTANCE);
@@ -71,7 +71,7 @@ public class FilterSettings {
         persistentStorage.putLong(FILTER_EVENTS_CATEGORY_KEY, categoryId);
     }
 
-    public boolean getCurrentLocation() {
+    public boolean isUsingCurrentLocation() {
         return persistentStorage.getBoolean(FILTER_EVENTS_CURRENT_LOCATION_KEY, DEFAULT_CURRENT_LOCATION);
     }
 

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsFragment.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsFragment.java
@@ -130,7 +130,7 @@ public class FilterEventsFragment extends BaseFragment
 
         button.setOnClickListener(v -> {
             presenter.storeDistance(seekBarProgress);
-            Log.i("jJJJJ", "lat, lon: " + lat + ", " + lon);
+            Log.i(TAG, "lat, lon: " + lat + ", " + lon);
 
             presenter.storeCurrentLocationStatus(locationIsChecked);
             presenter.storeLocation(location, lat, lon);

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsPresenter.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/event/filter/FilterEventsPresenter.java
@@ -81,7 +81,7 @@ public class FilterEventsPresenter extends MvpBasePresenter<FilterEventsView> {
     }
 
     public void loadCurrentLocationStatus() {
-        getView().setCurrentLocationStatus(filterSettings.getCurrentLocation());
+        getView().setCurrentLocationStatus(filterSettings.isUsingCurrentLocation());
     }
 
 }

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/event/search/list/EventsPresenter.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/event/search/list/EventsPresenter.java
@@ -1,14 +1,6 @@
 package io.hobaskos.event.eventapp.ui.event.search.list;
 
-import android.location.Location;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
-
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.location.LocationServices;
 
 import org.greenrobot.eventbus.EventBus;
 import org.joda.time.DateTime;
@@ -43,10 +35,9 @@ public class EventsPresenter extends BaseRxLcePresenter<EventsView, List<Event>>
 
     private Subscriber<List<Event>> moreEventSubscriber;
 
-    private PersistentStorage persistentStorage;
     private FilterSettings filterSettings;
 
-    private boolean useCurrentLocation;
+    private boolean usingCurrentLocation;
 
     private int distance;
     private double lat;
@@ -73,7 +64,6 @@ public class EventsPresenter extends BaseRxLcePresenter<EventsView, List<Event>>
                            PersistentStorage persistentStorage) {
         this.eventRepository = eventRepository;
         this.filterSettings = filterSettings;
-        this.persistentStorage = persistentStorage;
 
         //this.gpsService = new GPSService();
         this.gpsTracker = new GPSTracker(App.getInst().getApplicationContext());
@@ -166,9 +156,9 @@ public class EventsPresenter extends BaseRxLcePresenter<EventsView, List<Event>>
         lon = filterSettings.getPlaceLon();
         categoryId = filterSettings.getCategoryId();
 
-        useCurrentLocation = filterSettings.getCurrentLocation();
+        usingCurrentLocation = filterSettings.isUsingCurrentLocation();
 
-        if (useCurrentLocation) {
+        if (usingCurrentLocation) {
             Log.i(TAG, " USE CURRENT LOCATION");
             lat = gpsTracker.getLatitude();
             lon = gpsTracker.getLongitude();

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/main/MainActivity.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/main/MainActivity.java
@@ -60,14 +60,7 @@ public class MainActivity extends BaseViewStateActivity<MainView, MainPresenter>
 
     public final static String TAG = MainActivity.class.getName();
 
-    // Permissions:
-    private static final String[] INITIAL_PERMS={
-            Manifest.permission.ACCESS_FINE_LOCATION
-    };
 
-    // Permission Request:
-    private static final int INITIAL_REQUEST=1337;
-    private static final int LOCATION_REQUEST=INITIAL_REQUEST+3;
 
     // Views:
     private NavigationView navigationView;
@@ -97,9 +90,6 @@ public class MainActivity extends BaseViewStateActivity<MainView, MainPresenter>
         if(!googleServicesAvailable()) {
             Log.i("MainActivity", "Google services is not working");
         }
-
-        // Request permissions:
-        ActivityCompat.requestPermissions(this, INITIAL_PERMS, INITIAL_REQUEST);
 
         // Find views:
         drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/splash/SplashScreenActivity.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/splash/SplashScreenActivity.java
@@ -1,0 +1,48 @@
+package io.hobaskos.event.eventapp.ui.splash;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Handler;
+
+import com.google.gson.JsonParser;
+
+import io.hobaskos.event.eventapp.R;
+import io.hobaskos.event.eventapp.ui.main.MainActivity;
+
+/**
+ * Created by test on 3/26/2017.
+ */
+
+public class SplashScreenActivity extends Activity {
+
+    // Splash screen timer
+    private static int SPLASH_TIME_OUT = 2000;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_splash_screen);
+
+        new Handler().postDelayed(new Runnable() {
+
+            /*
+             * Showing splash screen with a timer. This will be useful when you
+             * want to show case your app logo / company
+             */
+
+            @Override
+            public void run() {
+                // This method will be executed once the timer is over
+                // Start your app main activity
+                Intent i = new Intent(SplashScreenActivity.this, MainActivity.class);
+                startActivity(i);
+
+                // close this activity
+                finish();
+            }
+        }, SPLASH_TIME_OUT);
+    }
+
+}

--- a/app/src/main/java/io/hobaskos/event/eventapp/ui/splash/SplashScreenActivity.java
+++ b/app/src/main/java/io/hobaskos/event/eventapp/ui/splash/SplashScreenActivity.java
@@ -1,10 +1,13 @@
 package io.hobaskos.event.eventapp.ui.splash;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v13.app.ActivityCompat;
 
 import com.google.gson.JsonParser;
 
@@ -17,32 +20,38 @@ import io.hobaskos.event.eventapp.ui.main.MainActivity;
 
 public class SplashScreenActivity extends Activity {
 
-    // Splash screen timer
-    private static int SPLASH_TIME_OUT = 2000;
+    // Permissions:
+    private static final String[] INITIAL_PERMS={
+            Manifest.permission.ACCESS_FINE_LOCATION
+    };
+
+    // Permission Request:
+    private static final int INITIAL_REQUEST=1337;
+    private static final int LOCATION_REQUEST=INITIAL_REQUEST+3;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash_screen);
 
-        new Handler().postDelayed(new Runnable() {
+        // Request permissions:
+        ActivityCompat.requestPermissions(SplashScreenActivity.this, INITIAL_PERMS, INITIAL_REQUEST);
 
-            /*
-             * Showing splash screen with a timer. This will be useful when you
-             * want to show case your app logo / company
-             */
-
-            @Override
-            public void run() {
-                // This method will be executed once the timer is over
-                // Start your app main activity
-                Intent i = new Intent(SplashScreenActivity.this, MainActivity.class);
-                startActivity(i);
-
-                // close this activity
-                finish();
-            }
-        }, SPLASH_TIME_OUT);
     }
+
+    //TODO: More advanced request handling
+    // http://stackoverflow.com/questions/33266328/how-can-i-customize-permission-dialog-in-android
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        // Start MainActivity after all preconfiguration and loading is done
+        Intent i = new Intent(SplashScreenActivity.this, MainActivity.class);
+        startActivity(i);
+
+        // close this activity
+        finish();
+    }
+
+
 
 }

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimaryDark" >
+
+    <ImageView
+        android:id="@+id/imgLogo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:src="@mipmap/eventure_logo" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:textSize="12dp"
+        android:textColor="#454545"
+        android:gravity="center_horizontal"
+        android:layout_alignParentBottom="true"
+        android:text="www.androidhive.info" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -11,14 +11,14 @@
         android:layout_centerInParent="true"
         android:src="@mipmap/eventure_logo" />
 
-    <TextView
-        android:layout_width="fill_parent"
+    <ProgressBar
+        android:id="@+id/ProgressBar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="10dp"
-        android:textSize="12dp"
-        android:textColor="#454545"
-        android:gravity="center_horizontal"
-        android:layout_alignParentBottom="true"
-        android:text="www.androidhive.info" />
+        android:layout_marginTop="24dp"
+        android:layout_below="@+id/imgLogo"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true" >
+    </ProgressBar>
 
 </RelativeLayout>


### PR DESCRIPTION
Also fixes #FRONTEND-155 & #FRONTEND-157

Request permissions happens in splash screen, which waits for the request dialog result before jumping to MainActivity. This fixes bug with events list showing empty results on a fresh app install (because current location coordinates are pulled/fragment is created, before location permissions are granted by user)

![screenshot_1490558732](https://cloud.githubusercontent.com/assets/431761/24334749/77007da4-1270-11e7-9fc2-fce8eecb2720.png)
![screenshot_1490558736](https://cloud.githubusercontent.com/assets/431761/24334750/7a3723f6-1270-11e7-9f4b-543ededc74c1.png)
![screenshot_1490558742](https://cloud.githubusercontent.com/assets/431761/24334752/7de680f0-1270-11e7-9664-18b0ac7bf3b9.png)
